### PR TITLE
feat: update deepgram chart and smoke testing tool

### DIFF
--- a/charts/deepgram-self-hosted/CHANGELOG.md
+++ b/charts/deepgram-self-hosted/CHANGELOG.md
@@ -4,6 +4,31 @@ All notable changes to this Helm chart will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.32.0-vf.1] - 2026-03-25
+
+### Changed
+
+- Synced with upstream Deepgram self-hosted chart v0.32.0 (from v0.23.1)
+- Updated default container tags to March 2026 release (`release-260319`)
+
+### Added
+
+- **BREAKING**: Replaced `[half_precision]` engine config with `[health]` section containing `gpu_required` (auto-detection by new images)
+- Added `engine.features.useV2LanguageDetection` for 36-language detection model support
+- Added `engine.flux.max_streams` for production Flux workload configuration
+- Added `engine.modelManager.volumes.aws.efs.ttlSecondsAfterFinished` to prevent completed Job pods from blocking PVC
+- Added EFS StorageClass configurability (`storageClass.create`, `storageClass.name`) for restricted environments
+- Added `engine.runtimeClassName` for KOPS-managed NVIDIA drivers or non-default containerd runtimes
+- Added `engine.lifecycle.postStart.command` for optional container postStart hooks
+- Added `engine.resources.gpuResourceName` for configurable GPU resource names (MIG support)
+- Added `extraEnv` support for API, Engine, and License Proxy deployments (supports `valueFrom` references)
+- Added `aura2.polyglot` configuration block for multilingual TTS (Dutch, German, French, Italian, Japanese)
+- Added `monitoring/` directory with Grafana dashboard template and alerting guide
+
+### Removed
+
+- Removed `engine.halfPrecision.state` configuration (replaced by `engine.health.gpuRequired`)
+
 ## [0.23.1] - 2025-11-04
 
 ### Fixed
@@ -316,7 +341,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Initial implementation of the Helm chart.
 
 
-[unreleased]: https://github.com/deepgram/self-hosted-resources/compare/deepgram-self-hosted-0.23.0...HEAD
+[unreleased]: https://github.com/deepgram/self-hosted-resources/compare/deepgram-self-hosted-0.32.0...HEAD
+[0.32.0-vf.1]: https://github.com/deepgram/self-hosted-resources/compare/deepgram-self-hosted-0.23.1...deepgram-self-hosted-0.32.0
 [0.23.0]: https://github.com/deepgram/self-hosted-resources/compare/deepgram-self-hosted-0.22.0...deepgram-self-hosted-0.23.0
 [0.22.0]: https://github.com/deepgram/self-hosted-resources/compare/deepgram-self-hosted-0.21.0...deepgram-self-hosted-0.22.0
 [0.21.0]: https://github.com/deepgram/self-hosted-resources/compare/deepgram-self-hosted-0.20.0...deepgram-self-hosted-0.21.0

--- a/charts/deepgram-self-hosted/CHANGELOG.md
+++ b/charts/deepgram-self-hosted/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this Helm chart will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.32.0-vf.1] - 2026-03-25
+## [0.32.0-vf.3] - 2026-03-26
 
 ### Changed
 

--- a/charts/deepgram-self-hosted/Chart.yaml
+++ b/charts/deepgram-self-hosted/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: deepgram-self-hosted
 type: application
-version: 0.23.1-vf.2 # (upstream: 0.23.1, voiceflow: 2)
-appVersion: "release-251029"
+version: 0.32.0-vf.3 # (upstream: 0.32.0, voiceflow: 3)
+appVersion: "release-260319"
 description: A Helm chart for running Deepgram services in a self-hosted environment
 home: "https://developers.deepgram.com/docs/self-hosted-introduction"
 sources: ["https://github.com/deepgram/self-hosted-resources"]

--- a/charts/deepgram-self-hosted/README.md
+++ b/charts/deepgram-self-hosted/README.md
@@ -1,6 +1,6 @@
 # deepgram-self-hosted
 
-![Version: 0.23.1](https://img.shields.io/badge/Version-0.23.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: release-251029](https://img.shields.io/badge/AppVersion-release--251029-informational?style=flat-square) [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/deepgram-self-hosted)](https://artifacthub.io/packages/search?repo=deepgram-self-hosted)
+![Version: 0.32.0-vf.1](https://img.shields.io/badge/Version-0.32.0--vf.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: release-260319](https://img.shields.io/badge/AppVersion-release--251029-informational?style=flat-square) [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/deepgram-self-hosted)](https://artifacthub.io/packages/search?repo=deepgram-self-hosted)
 
 A Helm chart for running Deepgram services in a self-hosted environment
 
@@ -272,7 +272,7 @@ If you encounter issues while deploying or using Deepgram, consider the followin
 | api.features.redactUsage | bool | `true` | Enables usage metadata redaction; set to false to disable redaction of usage metadata |
 | api.image.path | string | `"quay.io/deepgram/self-hosted-api"` | path configures the image path to use for creating API containers. You may change this from the public Quay image path if you have imported Deepgram images into a private container registry. |
 | api.image.pullPolicy | string | `"IfNotPresent"` | pullPolicy configures how the Kubelet attempts to pull the Deepgram API image |
-| api.image.tag | string | `"release-251029"` | tag defines which Deepgram release to use for API containers |
+| api.image.tag | string | `"release-260319"` | tag defines which Deepgram release to use for API containers |
 | api.livenessProbe | object | `` | Liveness probe customization for API pods. |
 | api.namePrefix | string | `"deepgram-api"` | namePrefix is the prefix to apply to the name of all K8s objects associated with the Deepgram API containers. |
 | api.nodeSelector | object | `{}` | [Node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) to apply to API pods. |
@@ -326,7 +326,7 @@ If you encounter issues while deploying or using Deepgram, consider the followin
 | engine.halfPrecision.state | string | `"auto"` | Engine will automatically enable half precision operations if your GPU supports them. You can explicitly enable or disable this behavior with the state parameter which supports `"enable"`, `"disabled"`, and `"auto"`. |
 | engine.image.path | string | `"quay.io/deepgram/self-hosted-engine"` | path configures the image path to use for creating Engine containers. You may change this from the public Quay image path if you have imported Deepgram images into a private container registry. |
 | engine.image.pullPolicy | string | `"IfNotPresent"` | pullPolicy configures how the Kubelet attempts to pull the Deepgram Engine image |
-| engine.image.tag | string | `"release-251029"` | tag defines which Deepgram release to use for Engine containers |
+| engine.image.tag | string | `"release-260319"` | tag defines which Deepgram release to use for Engine containers |
 | engine.livenessProbe | object | `` | Liveness probe customization for Engine pods. |
 | engine.metricsServer | object | `` | metricsServer exposes an endpoint on each Engine container for reporting inference-specific system metrics. See https://developers.deepgram.com/docs/metrics-guide#deepgram-engine for more details. |
 | engine.metricsServer.host | string | `"0.0.0.0"` | host is the IP address to listen on for metrics requests. You will want to listen on all interfaces to interact with other pods in the cluster. |
@@ -392,7 +392,7 @@ If you encounter issues while deploying or using Deepgram, consider the followin
 | licenseProxy.enabled | bool | `false` | The License Proxy is optional, but highly recommended to be deployed in production to enable highly available environments. |
 | licenseProxy.image.path | string | `"quay.io/deepgram/self-hosted-license-proxy"` | path configures the image path to use for creating License Proxy containers. You may change this from the public Quay image path if you have imported Deepgram images into a private container registry. |
 | licenseProxy.image.pullPolicy | string | `"IfNotPresent"` | pullPolicy configures how the Kubelet attempts to pull the Deepgram License Proxy image |
-| licenseProxy.image.tag | string | `"release-251029"` | tag defines which Deepgram release to use for License Proxy containers |
+| licenseProxy.image.tag | string | `"release-260319"` | tag defines which Deepgram release to use for License Proxy containers |
 | licenseProxy.keepUpstreamServerAsBackup | bool | `true` | Even with a License Proxy deployed, API and Engine pods can be configured to keep the upstream `license.deepgram.com` license server as a fallback licensing option if the License Proxy is unavailable. Disable this option if you are restricting API/Engine Pod network access for security reasons, and only the License Proxy should send egress traffic to the upstream license server. |
 | licenseProxy.livenessProbe | object | `` | Liveness probe customization for Proxy pods. |
 | licenseProxy.namePrefix | string | `"deepgram-license-proxy"` | namePrefix is the prefix to apply to the name of all K8s objects associated with the Deepgram License Proxy containers. |

--- a/charts/deepgram-self-hosted/samples/04-aura-2-setup.values.yaml
+++ b/charts/deepgram-self-hosted/samples/04-aura-2-setup.values.yaml
@@ -22,7 +22,7 @@ scaling:
 # API configuration for English Aura-2
 api:
   image:
-    tag: release-251029
+    tag: release-260319
   
   # Enable Aura-2 specific features
   features:
@@ -38,7 +38,7 @@ api:
 # Engine configuration for Aura-2
 engine:
   image:
-    tag: release-251029
+    tag: release-260319
   
   # Aura-2 requires more resources than standard models
   resources:
@@ -89,7 +89,7 @@ licenseProxy:
   keepUpstreamServerAsBackup: true
   
   image:
-    tag: release-251029
+    tag: release-260319
 
 # Monitoring configuration for Aura-2
 # Enable Prometheus stack for metrics collection

--- a/charts/deepgram-self-hosted/templates/api/api.deployment.yaml
+++ b/charts/deepgram-self-hosted/templates/api/api.deployment.yaml
@@ -72,6 +72,9 @@ spec:
           value: {{ .value | quote }}
         {{- end }}
         {{- end }}
+        {{- with .Values.api.extraEnv }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         - name: OPENAI_API_KEY
           {{- if and .Values.global.thirdPartyCredentials .Values.global.thirdPartyCredentials.openAiSecretRef }}
           valueFrom:

--- a/charts/deepgram-self-hosted/templates/engine/engine.config.yaml
+++ b/charts/deepgram-self-hosted/templates/engine/engine.config.yaml
@@ -46,9 +46,13 @@ data:
       multichannel = true
       language_detection = true
       streaming_ner = {{ .Values.engine.features.streamingNer }}
+      use_v2_language_detection = {{ .Values.engine.features.useV2LanguageDetection }}
 
     [flux]
       enabled = {{ .Values.engine.flux.enabled }}
+      {{- if .Values.engine.flux.max_streams }}
+      max_streams = {{ .Values.engine.flux.max_streams }}
+      {{- end }}
 
     [chunking.batch]
       {{- if .Values.engine.chunking.speechToText.batch.minDuration }}
@@ -67,8 +71,8 @@ data:
       {{- end }}
       step = {{ .Values.engine.chunking.speechToText.streaming.step }}
 
-    [half_precision]
-      state = "{{ .Values.engine.halfPrecision.state }}"
+    [health]
+      gpu_required = {{ .Values.engine.health.gpuRequired }}
 
     {{- if .Values.engine.customToml }}
     {{ .Values.engine.customToml | nindent 4 }}

--- a/charts/deepgram-self-hosted/templates/engine/engine.deployment.yaml
+++ b/charts/deepgram-self-hosted/templates/engine/engine.deployment.yaml
@@ -72,6 +72,9 @@ spec:
       {{- if or $.Values.engine.serviceAccount.create $.Values.engine.serviceAccount.name }}
       serviceAccountName: {{ default (printf "%s-sa" $.Values.engine.namePrefix) $.Values.engine.serviceAccount.name }}
       {{- end }}
+      {{- with $.Values.engine.runtimeClassName }}
+      runtimeClassName: {{ . }}
+      {{- end }}
       containers:
       - name: {{ $.Values.engine.namePrefix }}{{- if $type }}-{{ $type }}{{- end }}
         {{- with $.Values.engine.containerSecurityContext }}
@@ -80,6 +83,13 @@ spec:
         {{- end }}
         image: {{ $.Values.engine.image.path }}:{{ $.Values.engine.image.tag }}
         imagePullPolicy: {{ $.Values.engine.image.pullPolicy }}
+        {{- if $.Values.engine.lifecycle.postStart.command }}
+        lifecycle:
+          postStart:
+            exec:
+              command:
+                {{- toYaml $.Values.engine.lifecycle.postStart.command | nindent 16 }}
+        {{- end }}
         envFrom:
         - secretRef:
             name: {{ required "Missing Deepgram self-hosted API key - see `global.deepgramSecretRef`" $.Values.global.deepgramSecretRef }}
@@ -96,8 +106,20 @@ spec:
           value: {{ .value | quote }}
         {{- end }}
         {{- end }}
+        {{- with $.Values.engine.extraEnv }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         {{- if $.Values.aura2.enabled }}
-        {{- if $.Values.aura2.english.enabled }}
+        {{- if $.Values.aura2.polyglot.enabled }}
+        - name: IMPELLER_AURA2_MAX_BATCH_SIZE
+          value: "{{ $.Values.aura2.polyglot.maxBatchSize }}"
+        - name: IMPELLER_AURA2_T2C_UUID
+          value: "{{ $.Values.aura2.polyglot.t2cUuid }}"
+        - name: IMPELLER_AURA2_C2A_UUID
+          value: "{{ $.Values.aura2.polyglot.c2aUuid }}"
+        - name: CUDA_VISIBLE_DEVICES
+          value: "{{ $.Values.aura2.polyglot.cudaVisibleDevices }}"
+        {{- else if $.Values.aura2.english.enabled }}
         - name: IMPELLER_AURA2_MAX_BATCH_SIZE
           value: "{{ $.Values.aura2.english.maxBatchSize }}"
         - name: IMPELLER_AURA2_T2C_UUID
@@ -125,7 +147,7 @@ spec:
             memory: "{{ $.Values.engine.resources.requests.memory }}"
             cpu: "{{ $.Values.engine.resources.requests.cpu }}"
             {{- if gt (int $.Values.engine.resources.requests.gpu) 0 }}
-            nvidia.com/gpu: {{ $.Values.engine.resources.requests.gpu }}
+            {{ $.Values.engine.resources.gpuResourceName }}: {{ $.Values.engine.resources.requests.gpu }}
             {{- end }}
           limits:
             {{- if $.Values.engine.resources.limits.memory }}
@@ -135,7 +157,7 @@ spec:
             cpu: "{{ $.Values.engine.resources.limits.cpu }}"
             {{- end }}
             {{- if gt (int $.Values.engine.resources.limits.gpu) 0 }}
-            nvidia.com/gpu: {{ $.Values.engine.resources.limits.gpu }}
+            {{ $.Values.engine.resources.gpuResourceName }}: {{ $.Values.engine.resources.limits.gpu }}
             {{- end }}
         volumeMounts:
         - name: engine-config-volume

--- a/charts/deepgram-self-hosted/templates/license-proxy/license-proxy.deployment.yaml
+++ b/charts/deepgram-self-hosted/templates/license-proxy/license-proxy.deployment.yaml
@@ -64,6 +64,9 @@ spec:
         env:
         - name: DEEPGRAM_DEPLOYMENT_ORCHESTRATOR
           value: helm-{{ include "deepgram-self-hosted.chart" . }}
+        {{- with .Values.licenseProxy.extraEnv }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         command: [ "hermes" ]
         args: ["-v", "serve", "/etc/config/license-proxy.toml"]
         resources:

--- a/charts/deepgram-self-hosted/templates/volumes/aws/efs-model-download.job.yaml
+++ b/charts/deepgram-self-hosted/templates/volumes/aws/efs-model-download.job.yaml
@@ -10,6 +10,9 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
 spec:
+  {{- if .Values.engine.modelManager.volumes.aws.efs.ttlSecondsAfterFinished }}
+  ttlSecondsAfterFinished: {{ .Values.engine.modelManager.volumes.aws.efs.ttlSecondsAfterFinished }}
+  {{- end }}
   template:
     spec:
       affinity:

--- a/charts/deepgram-self-hosted/templates/volumes/aws/efs.pv.yaml
+++ b/charts/deepgram-self-hosted/templates/volumes/aws/efs.pv.yaml
@@ -16,7 +16,7 @@ spec:
   claimRef:
     name: {{ .Values.engine.modelManager.volumes.aws.efs.namePrefix }}-aws-efs-pvc
     namespace: {{ .Release.Namespace }}
-  storageClassName: aws-efs-sc
+  storageClassName: {{ .Values.engine.modelManager.volumes.aws.efs.storageClass.name | default (printf "%s-aws-efs-sc" .Values.engine.modelManager.volumes.aws.efs.namePrefix) }}
   persistentVolumeReclaimPolicy: Retain
   csi:
     driver: efs.csi.aws.com

--- a/charts/deepgram-self-hosted/templates/volumes/aws/efs.pvc.yaml
+++ b/charts/deepgram-self-hosted/templates/volumes/aws/efs.pvc.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   accessModes:
     - ReadWriteMany
-  storageClassName: {{ .Values.engine.modelManager.volumes.aws.efs.namePrefix }}-aws-efs-sc
+  storageClassName: {{ .Values.engine.modelManager.volumes.aws.efs.storageClass.name | default (printf "%s-aws-efs-sc" .Values.engine.modelManager.volumes.aws.efs.namePrefix) }}
   resources:
     requests:
       storage: 5Gi

--- a/charts/deepgram-self-hosted/templates/volumes/aws/efs.storageClass.yaml
+++ b/charts/deepgram-self-hosted/templates/volumes/aws/efs.storageClass.yaml
@@ -1,9 +1,11 @@
 {{- if .Values.engine.modelManager.volumes.aws.efs.enabled }}
+{{- if .Values.engine.modelManager.volumes.aws.efs.storageClass.create }}
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: {{ .Values.engine.modelManager.volumes.aws.efs.namePrefix }}-aws-efs-sc
+  name: {{ .Values.engine.modelManager.volumes.aws.efs.storageClass.name | default (printf "%s-aws-efs-sc" .Values.engine.modelManager.volumes.aws.efs.namePrefix) }}
   labels:
 {{ include "deepgram-self-hosted.labels" . | indent 4}}
 provisioner: efs.csi.aws.com
+{{- end }}
 {{- end }}

--- a/charts/deepgram-self-hosted/values.yaml
+++ b/charts/deepgram-self-hosted/values.yaml
@@ -237,6 +237,17 @@ api:
     - name: DD_SERVICE
       value: "deepgram-api"
 
+  # -- (list) Additional environment variables to add to the API container.
+  # Supports both plain values and valueFrom references (secretKeyRef, configMapKeyRef).
+  extraEnv: []
+  # - name: MY_VAR
+  #   value: "my-value"
+  # - name: MY_SECRET
+  #   valueFrom:
+  #     secretKeyRef:
+  #       name: my-secret
+  #       key: my-key
+
   podAnnotations:
     ad.datadoghq.com/deepgram-engine.checks: |
       {
@@ -262,7 +273,7 @@ api:
     # -- pullPolicy configures how the Kubelet attempts to pull the Deepgram API image
     pullPolicy: IfNotPresent
     # -- tag defines which Deepgram release to use for API containers
-    tag: release-251029
+    tag: release-260319
 
   # -- Additional labels to add to API resources
   additionalLabels: {}
@@ -468,6 +479,17 @@ engine:
     - name: DD_SERVICE
       value: "deepgram-engine"
 
+  # -- (list) Additional environment variables to add to the Engine container.
+  # Supports both plain values and valueFrom references (secretKeyRef, configMapKeyRef).
+  extraEnv: []
+  # - name: MY_VAR
+  #   value: "my-value"
+  # - name: MY_SECRET
+  #   valueFrom:
+  #     secretKeyRef:
+  #       name: my-secret
+  #       key: my-key
+
   image:
     # -- path configures the image path to use for creating Engine containers.
     # You may change this from the public Quay image path if you have imported
@@ -476,7 +498,7 @@ engine:
     # -- pullPolicy configures how the Kubelet attempts to pull the Deepgram Engine image
     pullPolicy: IfNotPresent
     # -- tag defines which Deepgram release to use for Engine containers
-    tag: release-251029
+    tag: release-260319
 
   # -- Additional labels to add to Engine resources
   additionalLabels: {}
@@ -523,13 +545,16 @@ engine:
     requests:
       memory: "30Gi"
       cpu: "4000m"
-      # -- gpu maps to the nvidia.com/gpu resource parameter
+      # -- gpu maps to the GPU resource parameter specified by gpuResourceName
       gpu: 1
     limits:
       memory: "40Gi"
       cpu: "8000m"
-      # -- gpu maps to the nvidia.com/gpu resource parameter
+      # -- gpu maps to the GPU resource parameter specified by gpuResourceName
       gpu: 1
+    # -- Configurable GPU resource name. Change this for MIG support
+    # (e.g., "nvidia.com/mig-1g.5gb") or other GPU resource types.
+    gpuResourceName: "nvidia.com/gpu"
 
   # -- The startupProbe combination of `periodSeconds` and `failureThreshold` allows
   # time for the container to load all models and start listening for incoming requests.
@@ -580,6 +605,17 @@ engine:
 
   # -- [Container-level security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) for Engine containers.
   containerSecurityContext: {}
+
+  # -- (string) Optional runtime class name for Engine pods. Use this if your cluster
+  # requires a non-default container runtime (e.g., for KOPS-managed NVIDIA drivers).
+  runtimeClassName:
+
+  # -- Optional lifecycle hooks for Engine containers.
+  # @default -- ``
+  lifecycle:
+    postStart:
+      # -- (list) Optional command to run after Engine container starts (e.g., ["/sbin/ldconfig"])
+      command: []
 
   serviceAccount:
     # -- Specifies whether to create a default service account for the Deepgram Engine Deployment.
@@ -659,6 +695,17 @@ engine:
           # -- Whether to force a fresh download of all model links provided,
           # even if models are already present in EFS.
           forceDownload: false
+          # -- (int) TTL in seconds for completed model download Job pods.
+          # Without this, completed Job pods retain a lock on PVC, preventing namespace deletion.
+          # Default: 86400 (24 hours)
+          ttlSecondsAfterFinished: 86400
+          storageClass:
+            # -- Whether to create a StorageClass resource for EFS.
+            # Set to false if using a pre-existing StorageClass in restricted environments.
+            create: true
+            # -- (string) Name of the StorageClass to use. If empty, defaults to
+            # "{namePrefix}-aws-efs-sc". Use this to reference an existing StorageClass.
+            name:
       gcp:
         gpd:
           # -- Whether to use an [GKE Persistent Disks](https://cloud.google.com/kubernetes-engine/docs/concepts/persistent-volumes)
@@ -701,10 +748,15 @@ engine:
     # -- Enables format entity tags on streaming audio
     # *if* a valid NER model is available.
     streamingNer: true
+    # -- Enables V2 language detection with 36-language detection model.
+    useV2LanguageDetection: false
 
   flux:
     # -- Enables Flux turn-based streaming STT
     enabled: false
+    # -- (int) Maximum number of concurrent Flux streams.
+    # Required for production Flux workloads; optimal value depends on GPU type.
+    max_streams:
 
   # -- chunking defines the size of audio chunks to process in seconds.
   # Adjusting these values will affect both inference performance and accuracy
@@ -730,11 +782,11 @@ engine:
         # representative for more details.
         step: 1.0
 
-  halfPrecision:
-    # -- Engine will automatically enable half precision operations if your GPU supports
-    # them. You can explicitly enable or disable this behavior with the state parameter
-    # which supports `"enable"`, `"disabled"`, and `"auto"`.
-    state: "auto"
+  health:
+    # -- Controls whether Engine fails on startup if no GPU is detected.
+    # While Engine can run without a GPU, production deployments require one.
+    # Set to true to fail fast if no GPU is available.
+    gpuRequired: false
 
 # -- Configuration options for the optional
 # [Deepgram License Proxy](https://developers.deepgram.com/docs/license-proxy).
@@ -761,13 +813,24 @@ licenseProxy:
   # associated with the Deepgram License Proxy containers.
   namePrefix: "deepgram-license-proxy"
 
+  # -- (list) Additional environment variables to add to the License Proxy container.
+  # Supports both plain values and valueFrom references (secretKeyRef, configMapKeyRef).
+  extraEnv: []
+  # - name: MY_VAR
+  #   value: "my-value"
+  # - name: MY_SECRET
+  #   valueFrom:
+  #     secretKeyRef:
+  #       name: my-secret
+  #       key: my-key
+
   image:
     # -- path configures the image path to use for creating License Proxy containers.
     # You may change this from the public Quay image path if you have imported
     # Deepgram images into a private container registry.
     path: quay.io/deepgram/self-hosted-license-proxy
     # -- tag defines which Deepgram release to use for License Proxy containers
-    tag: release-251029
+    tag: release-260319
     # -- pullPolicy configures how the Kubelet attempts to pull the Deepgram
     # License Proxy image
     pullPolicy: IfNotPresent
@@ -1079,3 +1142,13 @@ aura2:
     t2cUuid: ""
     c2aUuid: ""
     cudaVisibleDevices: "2,3"
+
+  # -- Polyglot (multilingual) configuration for Aura-2
+  # Supports Dutch, German, French, Italian, Japanese
+  # @default -- ``
+  polyglot:
+    enabled: false
+    maxBatchSize: 8
+    t2cUuid: ""
+    c2aUuid: ""
+    cudaVisibleDevices: "0,1"

--- a/docker/docker-compose.aura-2.yml
+++ b/docker/docker-compose.aura-2.yml
@@ -10,7 +10,7 @@ services:
   # The speech API service.
   # English Language Aura-2
   api-en:
-    image: quay.io/deepgram/self-hosted-api:release-251029
+    image: quay.io/deepgram/self-hosted-api:release-260319
     restart: always
 
     # Here we expose the API port to the host machine. The container port
@@ -37,7 +37,7 @@ services:
 
   # Spanish Language Aura-2
   api-es:
-    image: quay.io/deepgram/self-hosted-api:release-251029
+    image: quay.io/deepgram/self-hosted-api:release-260319
     restart: always
 
     # Here we expose the API port to the host machine. The container port
@@ -65,7 +65,7 @@ services:
   # The speech engine service.
   # English Language Aura-2 Driver
   engine-en:
-    image: quay.io/deepgram/self-hosted-engine:release-251029
+    image: quay.io/deepgram/self-hosted-engine:release-260319
     restart: always
 
     # Utilize a GPU, if available.
@@ -98,7 +98,7 @@ services:
 
   # Spanish Language Aura-2 Driver
   engine-es:
-    image: quay.io/deepgram/self-hosted-engine:release-251029
+    image: quay.io/deepgram/self-hosted-engine:release-260319
     restart: always
 
     # Utilize a GPU, if available.
@@ -131,7 +131,7 @@ services:
 
   # The service to validate your Deepgram license
   license-proxy:
-    image: quay.io/deepgram/self-hosted-license-proxy:release-251029
+    image: quay.io/deepgram/self-hosted-license-proxy:release-260319
     restart: always
 
     # Here we expose the License Proxy status port to the host machine. The container port

--- a/docker/docker-compose.license-proxy.yml
+++ b/docker/docker-compose.license-proxy.yml
@@ -9,7 +9,7 @@ x-env: &env
 services:
   # The speech API service.
   api:
-    image: quay.io/deepgram/self-hosted-api:release-251029
+    image: quay.io/deepgram/self-hosted-api:release-260319
     restart: always
 
     # Here we expose the API port to the host machine. The container port
@@ -35,7 +35,7 @@ services:
 
   # The speech engine service.
   engine:
-    image: quay.io/deepgram/self-hosted-engine:release-251029
+    image: quay.io/deepgram/self-hosted-engine:release-260319
     restart: always
 
     # Utilize a GPU, if available.
@@ -63,7 +63,7 @@ services:
 
   # The service to validate your Deepgram license
   license-proxy:
-    image: quay.io/deepgram/self-hosted-license-proxy:release-251029
+    image: quay.io/deepgram/self-hosted-license-proxy:release-260319
     restart: always
 
     # Here we expose the License Proxy status port to the host machine. The container port

--- a/docker/docker-compose.standard.yml
+++ b/docker/docker-compose.standard.yml
@@ -9,7 +9,7 @@ x-env: &env
 services:
   # The speech API service.
   api:
-    image: quay.io/deepgram/self-hosted-api:release-251029
+    image: quay.io/deepgram/self-hosted-api:release-260319
     restart: always
 
     # Here we expose the API port to the host machine. The container port
@@ -31,7 +31,7 @@ services:
 
   # The speech engine service.
   engine:
-    image: quay.io/deepgram/self-hosted-engine:release-251029
+    image: quay.io/deepgram/self-hosted-engine:release-260319
     restart: always
 
     # Utilize a GPU, if available.

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -1,0 +1,116 @@
+# Deepgram Self-Hosted Monitoring
+
+This repository contains a Grafana dashboard template for monitoring Deepgram self-hosted deployments.
+
+## Overview
+
+The dashboard provides monitoring of health and performance metrics including:
+
+- **Request Metrics**: Active requests, request rates, and status code breakdowns
+- **Error Monitoring**: Error rates (4xx/5xx) and per-pod error tracking
+- **Latency Metrics**: Batch and streaming latency at P50, P90, and P99 percentiles
+- **Capacity Monitoring**: Streaming load, capacity estimation, and saturation levels
+- **Per-Pod Metrics**: Individual pod performance and error rates
+
+## Requirements
+
+- Grafana 12.3.0 or higher
+- Prometheus datasource configured
+
+## Usage
+
+1. Import the `grafana_dashboard_template.json` file into your Grafana instance
+2. Configure the Prometheus datasource (DS_PROMETHEUS) when prompted
+3. The dashboard will automatically populate with metrics from your Prometheus instance
+
+## Dashboard Features
+
+The dashboard includes panels for:
+- Active requests per pod
+- Request rate by kind (RPS)
+- Error rate percentages
+- Status code breakdown
+- Batch and streaming latency percentiles
+- Stream capacity and load saturation
+- Connection latency
+- Per-pod error rates and latency metrics
+
+## Recommended Alerts
+
+### Example: Streaming P99 latency alert in Grafana
+
+1. In Grafana, go to **Alerting → Alert rules → New alert rule**.
+2. Choose the **Prometheus** data source (same as your dashboard).
+3. In the query editor, paste:
+
+   ```
+   histogram_quantile(
+     0.99,
+     sum by (namespace, le) (
+       rate(engine_stream_latency_bucket{namespace=~"dg-.*"}[5m])
+     )
+   )
+   ```
+
+4. Click **Run queries** to verify you see values.
+5. Under **Conditions**, set something like:
+   - WHEN `A` **IS ABOVE** `1.5`
+   - FOR `5m`
+6. Set:
+   - **Rule name**: `DeepgramHighStreamingP99Latency`
+   - **Folder**: `Deepgram SLOs`
+   - **Evaluation interval**: `30s` or `1m`
+7. Attach a **Contact point** (Slack, email, etc.) and a **Notification policy**.
+
+Repeat similar steps for:
+
+### Error rate alert
+
+**Query:**
+
+```
+(
+  sum by (namespace) (
+    rate(engine_requests_total{
+      namespace=~"dg-.*",
+      response_status=~"5.."
+    }[5m])
+  )
+  /
+  sum by (namespace) (
+    rate(engine_requests_total{
+      namespace=~"dg-.*"
+    }[5m])
+  )
+)
+```
+
+**Condition:**
+- WHEN `A` **IS ABOVE** `0.05`
+- FOR `2m`
+
+### Saturation alert
+
+**Query:**
+
+```
+100 *
+(
+  sum by (namespace) (
+    rate(engine_requests_total{
+      namespace=~"dg-.*",
+      kind="stream"
+    }[1m])
+  )
+  /
+  avg by (namespace) (
+    engine_estimated_stream_capacity{
+      namespace=~"dg-.*"
+    }
+  )
+)
+```
+
+**Condition:**
+- WHEN `A` **IS ABOVE** `70`
+- FOR `10m`

--- a/monitoring/grafana_dashboard_template.json
+++ b/monitoring/grafana_dashboard_template.json
@@ -1,0 +1,1309 @@
+{
+    "__inputs": [
+      {
+        "name": "DS_PROMETHEUS",
+        "label": "Prometheus",
+        "description": "",
+        "type": "datasource",
+        "pluginId": "prometheus",
+        "pluginName": "Prometheus"
+      }
+    ],
+    "__requires": [
+      {
+        "type": "grafana",
+        "id": "grafana",
+        "name": "Grafana",
+        "version": "12.3.0"
+      },
+      {
+        "type": "panel",
+        "id": "timeseries",
+        "name": "Time series",
+        "version": ""
+      },
+      {
+        "type": "panel",
+        "id": "stat",
+        "name": "Stat",
+        "version": ""
+      },
+      {
+        "type": "panel",
+        "id": "bargauge",
+        "name": "Bar gauge",
+        "version": ""
+      },
+      {
+        "type": "datasource",
+        "id": "prometheus",
+        "name": "Prometheus",
+        "version": "2.0.0"
+      }
+    ],
+    "annotations": {
+      "list": [
+        {
+          "builtIn": 1,
+          "datasource": "grafana",
+          "enable": true,
+          "hide": false,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "target": {
+            "limit": 100,
+            "matchAny": false,
+            "tags": [],
+            "type": "dashboard"
+          },
+          "type": "dashboard"
+        }
+      ]
+    },
+    "editable": true,
+    "fiscalYearStartMonth": 0,
+    "graphTooltip": 0,
+    "id": null,
+    "links": [],
+    "panels": [
+      {
+        "datasource": "${DS_PROMETHEUS}",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "showValues": false,
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": 0
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "none"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 0
+        },
+        "id": 3,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "table",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "hideZeros": false,
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "12.3.0",
+        "targets": [
+          {
+            "expr": "sum by (pod, kind) (engine_active_requests{namespace=~\"$namespace\", kind=~\"$kind\", pod=~\"$pod\"})",
+            "legendFormat": "{{pod}} ({{kind}})",
+            "refId": "A"
+          }
+        ],
+        "title": "Active Requests per Pod",
+        "type": "timeseries"
+      },
+      {
+        "datasource": "${DS_PROMETHEUS}",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "showValues": false,
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": 0
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "req/s"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 12,
+          "y": 0
+        },
+        "id": 4,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "table",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "hideZeros": false,
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "12.3.0",
+        "targets": [
+          {
+            "expr": "sum by (kind) (rate(engine_requests_total{namespace=~\"$namespace\", kind=~\"$kind\"}[5m]))",
+            "legendFormat": "{{kind}}",
+            "refId": "A"
+          }
+        ],
+        "title": "Request Rate by Kind (RPS)",
+        "type": "timeseries"
+      },
+      {
+        "datasource": "${DS_PROMETHEUS}",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "showValues": false,
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "max": 100,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": 0
+                },
+                {
+                  "color": "orange",
+                  "value": 2
+                },
+                {
+                  "color": "red",
+                  "value": 5
+                }
+              ]
+            },
+            "unit": "percent"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 8
+        },
+        "id": 5,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "table",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "hideZeros": false,
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "12.3.0",
+        "targets": [
+          {
+            "expr": "100 * (\n  sum(rate(engine_requests_total{namespace=~\"$namespace\", response_status=~\"4..|5..\"}[5m]))\n/\n  sum(rate(engine_requests_total{namespace=~\"$namespace\"}[5m]))\n)",
+            "legendFormat": "Error %",
+            "refId": "A"
+          }
+        ],
+        "title": "Error Rate (4xx + 5xx) %",
+        "type": "timeseries"
+      },
+      {
+        "datasource": "${DS_PROMETHEUS}",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "showValues": false,
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": 0
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "req/s"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 12,
+          "y": 8
+        },
+        "id": 6,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "table",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "hideZeros": false,
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "12.3.0",
+        "targets": [
+          {
+            "editorMode": "code",
+            "expr": "sum by (response_status) (engine_requests_total{namespace=~\"$namespace\"})",
+            "legendFormat": "{{response_status}}",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "Status Code Breakdown",
+        "type": "timeseries"
+      },
+      {
+        "datasource": "${DS_PROMETHEUS}",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "showValues": false,
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": 0
+                },
+                {
+                  "color": "orange",
+                  "value": 5
+                },
+                {
+                  "color": "red",
+                  "value": 10
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 16
+        },
+        "id": 9,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "table",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "hideZeros": false,
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "12.3.0",
+        "targets": [
+          {
+            "expr": "histogram_quantile(0.50, sum by (le) (rate(engine_batch_response_time_seconds_bucket{namespace=~\"$namespace\"}[5m])))",
+            "legendFormat": "P50",
+            "refId": "A"
+          },
+          {
+            "expr": "histogram_quantile(0.90, sum by (le) (rate(engine_batch_response_time_seconds_bucket{namespace=~\"$namespace\"}[5m])))",
+            "legendFormat": "P90",
+            "refId": "B"
+          },
+          {
+            "expr": "histogram_quantile(0.99, sum by (le) (rate(engine_batch_response_time_seconds_bucket{namespace=~\"$namespace\"}[5m])))",
+            "legendFormat": "P99",
+            "refId": "C"
+          }
+        ],
+        "title": "Batch Latency P50 / P90 / P99 (s)",
+        "type": "timeseries"
+      },
+      {
+        "datasource": "${DS_PROMETHEUS}",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "showValues": false,
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": 0
+                },
+                {
+                  "color": "orange",
+                  "value": 1
+                },
+                {
+                  "color": "red",
+                  "value": 1.5
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 12,
+          "y": 16
+        },
+        "id": 7,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "table",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "hideZeros": false,
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "12.3.0",
+        "targets": [
+          {
+            "expr": "histogram_quantile(0.50, sum by (le) (rate(engine_stream_latency_bucket{namespace=~\"$namespace\"}[5m])))",
+            "legendFormat": "P50",
+            "refId": "A"
+          },
+          {
+            "expr": "histogram_quantile(0.90, sum by (le) (rate(engine_stream_latency_bucket{namespace=~\"$namespace\"}[5m])))",
+            "legendFormat": "P90",
+            "refId": "B"
+          },
+          {
+            "expr": "histogram_quantile(0.99, sum by (le) (rate(engine_stream_latency_bucket{namespace=~\"$namespace\"}[5m])))",
+            "legendFormat": "P99",
+            "refId": "C"
+          }
+        ],
+        "title": "Streaming Latency P50 / P90 / P99 (s)",
+        "type": "timeseries"
+      },
+      {
+        "datasource": "${DS_PROMETHEUS}",
+        "fieldConfig": {
+          "defaults": {
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": 0
+                },
+                {
+                  "color": "orange",
+                  "value": 50
+                },
+                {
+                  "color": "red",
+                  "value": 100
+                }
+              ]
+            },
+            "unit": "none"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 6,
+          "w": 6,
+          "x": 0,
+          "y": 24
+        },
+        "id": 2,
+        "options": {
+          "displayMode": "gradient",
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": false
+          },
+          "maxVizHeight": 300,
+          "min": 0,
+          "minVizHeight": 16,
+          "minVizWidth": 8,
+          "namePlacement": "auto",
+          "orientation": "horizontal",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "showUnfilled": true,
+          "sizing": "auto",
+          "valueMode": "color"
+        },
+        "pluginVersion": "12.3.0",
+        "targets": [
+          {
+            "expr": "sum by (kind) (engine_active_requests{namespace=~\"$namespace\", kind=~\"$kind\"})",
+            "refId": "A"
+          }
+        ],
+        "title": "Active Requests by Kind",
+        "type": "bargauge"
+      },
+      {
+        "datasource": "${DS_PROMETHEUS}",
+        "fieldConfig": {
+          "defaults": {
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "red",
+                  "value": 0
+                },
+                {
+                  "color": "orange",
+                  "value": 3
+                },
+                {
+                  "color": "green",
+                  "value": 5
+                }
+              ]
+            },
+            "unit": "none"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 6,
+          "w": 6,
+          "x": 6,
+          "y": 24
+        },
+        "id": 1,
+        "options": {
+          "colorMode": "value",
+          "graphMode": "area",
+          "justifyMode": "center",
+          "orientation": "horizontal",
+          "percentChangeColorMode": "standard",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "showPercentChange": false,
+          "textMode": "auto",
+          "wideLayout": true
+        },
+        "pluginVersion": "12.3.0",
+        "targets": [
+          {
+            "expr": "sum(engine_estimated_stream_capacity{namespace=~\"$namespace\"})",
+            "refId": "A"
+          }
+        ],
+        "title": "Estimated Stream Capacity",
+        "type": "stat"
+      },
+      {
+        "datasource": "${DS_PROMETHEUS}",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "showValues": false,
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": 0
+                },
+                {
+                  "color": "orange",
+                  "value": 70
+                },
+                {
+                  "color": "red",
+                  "value": 90
+                }
+              ]
+            },
+            "unit": "percent"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 6,
+          "w": 12,
+          "x": 12,
+          "y": 24
+        },
+        "id": 11,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "hideZeros": false,
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "12.3.0",
+        "targets": [
+          {
+            "expr": "100 * (\n  sum(rate(engine_requests_total{namespace=~\"$namespace\", kind=\"stream\"}[1m]))\n/\n  avg(engine_estimated_stream_capacity{namespace=~\"$namespace\"})\n)",
+            "legendFormat": "Saturation",
+            "refId": "A"
+          }
+        ],
+        "title": "Streaming Load Saturation (% of Capacity)",
+        "type": "timeseries"
+      },
+      {
+        "datasource": "${DS_PROMETHEUS}",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "showValues": false,
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": 0
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 6,
+          "w": 12,
+          "x": 0,
+          "y": 30
+        },
+        "id": 8,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "hideZeros": false,
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "12.3.0",
+        "targets": [
+          {
+            "expr": "rate(engine_stream_latency_sum{namespace=~\"$namespace\"}[5m]) / rate(engine_stream_latency_count{namespace=~\"$namespace\"}[5m])",
+            "legendFormat": "Mean connection latency",
+            "refId": "A"
+          }
+        ],
+        "title": "Streaming Connection Latency (Mean, s)",
+        "type": "timeseries"
+      },
+      {
+        "datasource": "${DS_PROMETHEUS}",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "showValues": false,
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": 0
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "req/s"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 12,
+          "y": 30
+        },
+        "id": 13,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "table",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "hideZeros": false,
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "12.3.0",
+        "targets": [
+          {
+            "expr": "sum by (pod) (rate(engine_requests_total{namespace=~\"$namespace\", response_status=~\"5..\", pod=~\"$pod\"}[5m]))",
+            "legendFormat": "{{pod}}",
+            "refId": "A"
+          }
+        ],
+        "title": "Per-Pod Error Rate (5xx RPS)",
+        "type": "timeseries"
+      },
+      {
+        "datasource": "${DS_PROMETHEUS}",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "showValues": false,
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": 0
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "none"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 36
+        },
+        "id": 10,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "table",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "hideZeros": false,
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "12.3.0",
+        "targets": [
+          {
+            "expr": "sum(rate(engine_requests_total{namespace=~\"$namespace\", kind=\"stream\"}[1m]))",
+            "legendFormat": "Stream RPS",
+            "refId": "A"
+          },
+          {
+            "expr": "avg(engine_estimated_stream_capacity{namespace=~\"$namespace\"})",
+            "legendFormat": "Estimated capacity",
+            "refId": "B"
+          }
+        ],
+        "title": "Streaming Load vs Estimated Capacity",
+        "type": "timeseries"
+      },
+      {
+        "datasource": "${DS_PROMETHEUS}",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "showValues": false,
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": 0
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 44
+        },
+        "id": 12,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "table",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "hideZeros": false,
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "12.3.0",
+        "targets": [
+          {
+            "expr": "histogram_quantile(0.99, sum by (pod, le) (rate(engine_stream_latency_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))",
+            "legendFormat": "{{pod}}",
+            "refId": "A"
+          }
+        ],
+        "title": "Per-Pod Streaming Latency P99 (s)",
+        "type": "timeseries"
+      }
+    ],
+    "preload": false,
+    "refresh": "30s",
+    "schemaVersion": 42,
+    "tags": [
+      "deepgram",
+      "stt",
+      "tts",
+      "kubernetes"
+    ],
+    "templating": {
+      "list": [
+        {
+          "type": "datasource",
+          "name": "DS_PROMETHEUS",
+          "label": "Prometheus",
+          "query": "prometheus",
+          "refresh": 1,
+          "hide": 0
+        },
+        {
+          "allValue": ".*",
+          "datasource": "${DS_PROMETHEUS}",
+          "includeAll": true,
+          "label": "Namespace",
+          "name": "namespace",
+          "options": [],
+          "query": "label_values(kube_pod_info{pod=~\"deepgram-.*\"}, namespace)",
+          "refresh": 2,
+          "type": "query"
+        },
+        {
+          "allValue": ".*",
+          "datasource": "${DS_PROMETHEUS}",
+          "includeAll": true,
+          "label": "Kind",
+          "name": "kind",
+          "options": [],
+          "query": "label_values(engine_active_requests, kind)",
+          "refresh": 2,
+          "type": "query"
+        },
+        {
+          "allValue": ".*",
+          "datasource": "${DS_PROMETHEUS}",
+          "includeAll": true,
+          "label": "Pod",
+          "name": "pod",
+          "options": [],
+          "query": "label_values(engine_active_requests, pod)",
+          "refresh": 2,
+          "type": "query"
+        }
+      ]
+    },
+    "time": {
+      "from": "now-6h",
+      "to": "now"
+    },
+    "timepicker": {
+      "refresh_intervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h"
+      ]
+    },
+    "timezone": "",
+    "title": "Deepgram Self-Hosted - Health & Performance",
+    "uid": "deepgram-self-hosted",
+    "version": 1
+  }
+  

--- a/podman/podman-compose.aura-2.yml
+++ b/podman/podman-compose.aura-2.yml
@@ -4,7 +4,7 @@ services:
   # The speech API service.
   # English Language Aura-2
   api-en:
-    image: quay.io/deepgram/self-hosted-api:release-251029
+    image: quay.io/deepgram/self-hosted-api:release-260319
     restart: always
 
     # Here we expose the API port to the host machine. The container port
@@ -33,7 +33,7 @@ services:
 
   # Spanish Language Aura-2
   api-es:
-    image: quay.io/deepgram/self-hosted-api:release-251029
+    image: quay.io/deepgram/self-hosted-api:release-260319
     restart: always
 
     # Here we expose the API port to the host machine. The container port
@@ -63,7 +63,7 @@ services:
   # The speech engine service.
   # English Language Aura-2 Driver
   engine-en:
-    image: quay.io/deepgram/self-hosted-engine:release-251029
+    image: quay.io/deepgram/self-hosted-engine:release-260319
     restart: always
 
     # Utilize a GPU, if available.
@@ -99,7 +99,7 @@ services:
 
   # Spanish Language Aura-2 Driver
   engine-es:
-    image: quay.io/deepgram/self-hosted-engine:release-251029
+    image: quay.io/deepgram/self-hosted-engine:release-260319
     restart: always
 
     # Utilize a GPU, if available.
@@ -135,7 +135,7 @@ services:
 
   # The service to validate your Deepgram license
   license-proxy:
-    image: quay.io/deepgram/self-hosted-license-proxy:release-251029
+    image: quay.io/deepgram/self-hosted-license-proxy:release-260319
     restart: always
 
     # Here we expose the License Proxy status port to the host machine. The container port

--- a/podman/podman-compose.license-proxy.yml
+++ b/podman/podman-compose.license-proxy.yml
@@ -3,7 +3,7 @@
 services:
   # The speech API service.
   api:
-    image: quay.io/deepgram/self-hosted-api:release-251029
+    image: quay.io/deepgram/self-hosted-api:release-260319
     restart: always
 
     # Here we expose the API port to the host machine. The container port
@@ -32,7 +32,7 @@ services:
 
   # The speech engine service.
   engine:
-    image: quay.io/deepgram/self-hosted-engine:release-251029
+    image: quay.io/deepgram/self-hosted-engine:release-260319
     restart: always
 
     # Utilize a GPU, if available.
@@ -64,7 +64,7 @@ services:
 
   # The service to validate your Deepgram license
   license-proxy:
-    image: quay.io/deepgram/self-hosted-license-proxy:release-251029
+    image: quay.io/deepgram/self-hosted-license-proxy:release-260319
     restart: always
 
     # Here we expose the License Proxy status port to the host machine. The container port

--- a/podman/podman-compose.standard.yml
+++ b/podman/podman-compose.standard.yml
@@ -3,7 +3,7 @@
 services:
   # The speech API service.
   api:
-    image: quay.io/deepgram/self-hosted-api:release-251029
+    image: quay.io/deepgram/self-hosted-api:release-260319
     restart: always
 
     # Here we expose the API port to the host machine. The container port
@@ -28,7 +28,7 @@ services:
 
   # The speech engine service.
   engine:
-    image: quay.io/deepgram/self-hosted-engine:release-251029
+    image: quay.io/deepgram/self-hosted-engine:release-260319
     restart: always
 
     # Utilize a GPU, if available.

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,83 @@
+# Deepgram Self-Hosted Validation Tool
+
+A Go CLI tool to smoke-test a Deepgram self-hosted deployment. Validates health, streaming STT (v1), and Flux STT (v2) endpoints with real-time transcript streaming.
+
+## Prerequisites
+
+- Go 1.22+
+- Network access to the Deepgram API (via port-forward or direct)
+- A Deepgram API key
+
+## Setup
+
+Port-forward the Deepgram API service:
+
+```bash
+# Standard API (Nova streaming)
+kubectl port-forward svc/deepgram-api-external 8080:8080 -n deepgram
+
+# If Flux runs on a separate service/port
+kubectl port-forward svc/deepgram-flux-api-external 8081:8080 -n deepgram
+```
+
+## Build & Run
+
+```bash
+cd test
+go build -o dg-validate .
+
+# Using env var
+export DEEPGRAM_API_KEY=<your-api-key>
+
+# Test streaming STT only
+./dg-validate -model nova-2-general -skip-batch -skip-flux
+
+# Test Flux STT only
+./dg-validate -skip-batch -skip-streaming -flux-model flux-general-en
+
+# Test Flux on a separate port
+./dg-validate -skip-batch -skip-streaming -flux-url localhost:8081 -flux-model flux-general-en
+
+# Test both streaming and Flux
+./dg-validate -model nova-2-general -skip-batch -flux-model flux-general-en
+
+# Test Flux on a different API than streaming
+./dg-validate -model nova-2-general -skip-batch \
+  -flux-url localhost:8081 -flux-model flux-general-en
+```
+
+## Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `-url` | `localhost:8080` | Deepgram API host:port |
+| `-flux-url` | same as `-url` | Flux API host:port (if different from main API) |
+| `-key` | `DEEPGRAM_API_KEY` env | Deepgram API key |
+| `-model` | `nova-2-general` | Model name for streaming STT |
+| `-batch-model` | same as `-model` | Model for batch STT |
+| `-flux-model` | same as `-model` | Model for Flux STT (e.g. `flux-general-en`) |
+| `-language` | `en` | Language code for streaming/batch (e.g. en, es, fr) |
+| `-audio` | `../benchmarking/audio.8k.wav` | Path to test audio file (WAV) |
+| `-skip-batch` | `false` | Skip the Batch STT test |
+| `-skip-streaming` | `false` | Skip the Streaming STT test |
+| `-skip-flux` | `false` | Skip the Flux STT test |
+
+## Tests
+
+| Test | Endpoint | Protocol | Description |
+|------|----------|----------|-------------|
+| Health Check | `GET /v1/status/engine` | HTTP | Verifies engine is connected |
+| Batch STT | `POST /v1/listen` | HTTP | Sends audio file, verifies transcription (requires batch-capable model) |
+| Streaming STT | `ws:///v1/listen` | WebSocket | Streams audio in real-time, shows interim and final results |
+| Flux STT | `ws:///v2/listen` | WebSocket | Flux turn-based STT, streams transcript as words arrive |
+
+## Notes
+
+- **Streaming models only**: Most Deepgram models (Nova-2, Nova-3) are streaming-only. Use `-skip-batch` unless you have a batch-capable model loaded.
+- **Flux uses v2 endpoint**: Flux models require `/v2/listen` and the model name includes the language (e.g. `flux-general-en`), so the `-language` flag is not used for Flux.
+- **Port-forward stability**: A failed request (wrong model name, etc.) can crash `kubectl port-forward`. Restart it before retrying.
+- **Transcripts stream live**: Streaming STT shows interim (gray) and final (green) results. Flux shows words appearing as they're transcribed.
+
+## Audio File
+
+By default, the tool uses `../benchmarking/audio.8k.wav` (8kHz, 16-bit PCM mono, ~20 seconds). Use the `-audio` flag to specify a different file.

--- a/test/audio.go
+++ b/test/audio.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func loadAudio(path string) ([]byte, error) {
+	if path != "" {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("reading %s: %w", path, err)
+		}
+		fmt.Printf("  INFO  Using audio file: %s\n", path)
+		return data, nil
+	}
+
+	defaults := []string{
+		"../benchmarking/audio.8k.wav",
+		"benchmarking/audio.8k.wav",
+	}
+	for _, p := range defaults {
+		if data, err := os.ReadFile(p); err == nil {
+			fmt.Printf("  INFO  Using audio file: %s\n", p)
+			return data, nil
+		}
+	}
+
+	return nil, fmt.Errorf("no audio file found; use -audio flag to specify path (e.g. -audio ../benchmarking/audio.8k.wav)")
+}

--- a/test/batch.go
+++ b/test/batch.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+func testBatch(cfg *Config) error {
+	url := fmt.Sprintf("http://%s/v1/listen?model=%s&language=%s&smart_format=true", cfg.APIURL, cfg.BatchModel, cfg.Language)
+	req, err := http.NewRequest("POST", url, bytes.NewReader(cfg.Audio))
+	if err != nil {
+		return fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("Authorization", "Token "+cfg.APIKey)
+	req.Header.Set("Content-Type", "audio/wav")
+
+	client := &http.Client{Timeout: 60 * time.Second}
+	start := time.Now()
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+	elapsed := time.Since(start)
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("reading response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(body))
+	}
+
+	var result BatchResponse
+	if err := json.Unmarshal(body, &result); err != nil {
+		return fmt.Errorf("parsing response: %w", err)
+	}
+
+	if len(result.Results.Channels) == 0 {
+		return fmt.Errorf("no channels in response")
+	}
+	if len(result.Results.Channels[0].Alternatives) == 0 {
+		return fmt.Errorf("no alternatives in response")
+	}
+
+	transcript := result.Results.Channels[0].Alternatives[0].Transcript
+	fmt.Printf("         Transcript: %q\n", transcript)
+	fmt.Printf("         Responded in %s\n", elapsed.Round(time.Millisecond))
+	return nil
+}

--- a/test/flux.go
+++ b/test/flux.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+func testFlux(cfg *Config) error {
+	url := fmt.Sprintf("ws://%s/v2/listen?model=%s",
+		cfg.FluxURL, cfg.FluxModel)
+
+	fmt.Printf("         URL: %s\n", url)
+
+	header := http.Header{}
+	header.Set("Authorization", "Token "+cfg.APIKey)
+
+	conn, resp, err := websocket.DefaultDialer.Dial(url, header)
+	if err != nil {
+		if resp != nil {
+			body, _ := io.ReadAll(resp.Body)
+			resp.Body.Close()
+			return fmt.Errorf("websocket dial failed (HTTP %d): %s", resp.StatusCode, string(body))
+		}
+		return fmt.Errorf("websocket dial failed: %w", err)
+	}
+	defer conn.Close()
+
+	// Send audio chunks in background
+	sendDone := make(chan struct{})
+	go func() {
+		defer close(sendDone)
+		sendAudioChunks(conn, cfg.Audio)
+	}()
+
+	conn.SetReadDeadline(time.Now().Add(30 * time.Second))
+
+	messages := 0
+	lastPrinted := 0
+	gotTurnInfo := false
+	lastTranscript := ""
+
+	for {
+		_, msg, err := conn.ReadMessage()
+		if err != nil {
+			if websocket.IsCloseError(err, websocket.CloseNormalClosure, websocket.CloseNoStatusReceived) {
+				break
+			}
+			if gotTurnInfo {
+				break
+			}
+			return fmt.Errorf("reading message: %w", err)
+		}
+
+		var m FluxMessage
+		if err := json.Unmarshal(msg, &m); err != nil {
+			continue
+		}
+
+		if m.Type == "TurnInfo" {
+			gotTurnInfo = true
+			messages++
+			lastTranscript = m.Transcript
+
+			// Only print new characters when transcript grows
+			if len(m.Transcript) > lastPrinted {
+				fmt.Printf("%s", m.Transcript[lastPrinted:])
+				lastPrinted = len(m.Transcript)
+			}
+
+			if m.Event == "EndOfTurn" {
+				// Reset for next turn
+				lastPrinted = 0
+				fmt.Println()
+			}
+		}
+	}
+
+	<-sendDone
+
+	fmt.Println()
+	if lastTranscript != "" {
+		fmt.Printf("         Final: %s\n", lastTranscript)
+	}
+
+	if !gotTurnInfo {
+		return fmt.Errorf("no TurnInfo messages received")
+	}
+
+	fmt.Printf("         %d TurnInfo messages\n", messages)
+	return nil
+}

--- a/test/go.mod
+++ b/test/go.mod
@@ -1,0 +1,5 @@
+module github.com/voiceflow/deepgram-self-hosted-chart/test
+
+go 1.24.4
+
+require github.com/gorilla/websocket v1.5.3

--- a/test/go.sum
+++ b/test/go.sum
@@ -1,0 +1,2 @@
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=

--- a/test/health.go
+++ b/test/health.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+func testHealth(cfg *Config) error {
+	url := fmt.Sprintf("http://%s/v1/status/engine", cfg.APIURL)
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("Authorization", "Token "+cfg.APIKey)
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("reading response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(body))
+	}
+
+	var status EngineStatus
+	if err := json.Unmarshal(body, &status); err != nil {
+		return fmt.Errorf("parsing response: %w", err)
+	}
+
+	if status.EngineConnectionStatus != "Connected" {
+		return fmt.Errorf("engine status: %q (expected \"Connected\")", status.EngineConnectionStatus)
+	}
+
+	fmt.Printf("         engine_connection_status: %s\n", status.EngineConnectionStatus)
+	return nil
+}

--- a/test/main.go
+++ b/test/main.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"time"
+)
+
+// Config holds all settings for the validation run.
+type Config struct {
+	APIURL        string
+	FluxURL       string
+	APIKey        string
+	Model         string
+	BatchModel    string
+	FluxModel     string
+	Language      string
+	Audio         []byte
+	SkipFlux      bool
+	SkipBatch     bool
+	SkipStreaming bool
+}
+
+func main() {
+	apiURL := flag.String("url", "localhost:8080", "Deepgram API host:port")
+	apiKey := flag.String("key", "", "Deepgram API key (or set DEEPGRAM_API_KEY env)")
+	model := flag.String("model", "nova-2-general", "Model name for streaming/flux STT requests")
+	batchModel := flag.String("batch-model", "", "Model for batch STT (defaults to -model value)")
+	fluxModel := flag.String("flux-model", "", "Model for Flux STT (defaults to -model value)")
+	fluxURL := flag.String("flux-url", "", "Flux API host:port if different from -url")
+	language := flag.String("language", "en", "Language code (e.g. en, es, fr)")
+	audio := flag.String("audio", "", "Path to audio file (default: ../benchmarking/audio.8k.wav)")
+	skipFlux := flag.Bool("skip-flux", false, "Skip Flux STT test")
+	skipBatch := flag.Bool("skip-batch", false, "Skip Batch STT test")
+	skipStreaming := flag.Bool("skip-streaming", false, "Skip Streaming STT test")
+	flag.Parse()
+
+	key := *apiKey
+	if key == "" {
+		key = os.Getenv("DEEPGRAM_API_KEY")
+	}
+	if key == "" {
+		fmt.Println("ERROR: API key required. Use -key flag or set DEEPGRAM_API_KEY env var.")
+		os.Exit(1)
+	}
+
+	fmt.Println()
+	fmt.Println("Deepgram Self-Hosted Validation")
+	fmt.Println("================================")
+
+	audioData, err := loadAudio(*audio)
+	if err != nil {
+		fmt.Printf("  ERROR %v\n", err)
+		os.Exit(1)
+	}
+
+	bm := *batchModel
+	if bm == "" {
+		bm = *model
+	}
+	fm := *fluxModel
+	if fm == "" {
+		fm = *model
+	}
+	fu := *fluxURL
+	if fu == "" {
+		fu = *apiURL
+	}
+
+	cfg := &Config{
+		APIURL:        *apiURL,
+		FluxURL:       fu,
+		APIKey:        key,
+		Model:         *model,
+		BatchModel:    bm,
+		FluxModel:     fm,
+		Language:       *language,
+		Audio:         audioData,
+		SkipFlux:      *skipFlux,
+		SkipBatch:     *skipBatch,
+		SkipStreaming: *skipStreaming,
+	}
+
+	tests := []struct {
+		name string
+		fn   func(*Config) error
+		skip bool
+	}{
+		{"Health Check", testHealth, false},
+		{"Batch STT", testBatch, cfg.SkipBatch},
+		{"Streaming STT", testStreaming, cfg.SkipStreaming},
+		{"Flux STT", testFlux, cfg.SkipFlux},
+	}
+
+	passed, failed, skipped := 0, 0, 0
+	fmt.Println()
+
+	for _, t := range tests {
+		if t.skip {
+			fmt.Printf("  SKIP  %s\n", t.name)
+			skipped++
+			continue
+		}
+		fmt.Printf("  RUN   %s\n", t.name)
+		start := time.Now()
+		if err := t.fn(cfg); err != nil {
+			fmt.Printf("  FAIL  %s (%s): %v\n", t.name, time.Since(start).Round(time.Millisecond), err)
+			failed++
+		} else {
+			fmt.Printf("  PASS  %s (%s)\n", t.name, time.Since(start).Round(time.Millisecond))
+			passed++
+		}
+		fmt.Println()
+	}
+
+	fmt.Printf("Results: %d passed, %d failed, %d skipped\n\n", passed, failed, skipped)
+	if failed > 0 {
+		os.Exit(1)
+	}
+}

--- a/test/streaming.go
+++ b/test/streaming.go
@@ -1,0 +1,22 @@
+package main
+
+import "fmt"
+
+func testStreaming(cfg *Config) error {
+	url := fmt.Sprintf("ws://%s/v1/listen?model=%s&language=%s&smart_format=true&punctuate=true&interim_results=true",
+		cfg.APIURL, cfg.Model, cfg.Language)
+
+	res, err := runWebSocketTest(cfg, url)
+	if err != nil {
+		return err
+	}
+
+	if len(res.AllTranscripts) > 0 {
+		fmt.Println("         Full transcript:")
+		for i, t := range res.AllTranscripts {
+			fmt.Printf("           [%d] %s\n", i+1, t)
+		}
+	}
+	fmt.Printf("         %d messages, %d final\n", res.Messages, res.Finals)
+	return nil
+}

--- a/test/types.go
+++ b/test/types.go
@@ -1,0 +1,56 @@
+package main
+
+// EngineStatus is the response from GET /v1/status/engine.
+type EngineStatus struct {
+	EngineConnectionStatus string `json:"engine_connection_status"`
+}
+
+// BatchResponse is the response from POST /v1/listen.
+type BatchResponse struct {
+	Results BatchResults `json:"results"`
+}
+
+type BatchResults struct {
+	Channels []Channel `json:"channels"`
+}
+
+type Channel struct {
+	Alternatives []Alternative `json:"alternatives"`
+}
+
+type Alternative struct {
+	Transcript string `json:"transcript"`
+	Words      []Word `json:"words"`
+}
+
+type Word struct {
+	Word  string  `json:"word"`
+	Start float64 `json:"start"`
+	End   float64 `json:"end"`
+}
+
+// StreamingMessage is a WebSocket message from streaming or Flux STT.
+type StreamingMessage struct {
+	Type        string  `json:"type"`
+	IsFinal     bool    `json:"is_final"`
+	SpeechFinal bool    `json:"speech_final"`
+	Channel     Channel `json:"channel"`
+	Start       float64 `json:"start"`
+	Duration    float64 `json:"duration"`
+}
+
+// FluxMessage is a WebSocket message from Flux v2 STT.
+type FluxMessage struct {
+	Type                 string     `json:"type"`
+	Event                string     `json:"event"`
+	TurnIndex            int        `json:"turn_index"`
+	Transcript           string     `json:"transcript"`
+	Words                []FluxWord `json:"words"`
+	EndOfTurnConfidence  float64    `json:"end_of_turn_confidence"`
+	SequenceID           int        `json:"sequence_id"`
+}
+
+type FluxWord struct {
+	Word       string  `json:"word"`
+	Confidence float64 `json:"confidence"`
+}

--- a/test/ws.go
+++ b/test/ws.go
@@ -1,0 +1,157 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+type wsResult struct {
+	Messages       int
+	Finals         int
+	Transcript     string
+	AllTranscripts []string
+}
+
+func runWebSocketTest(cfg *Config, wsURL string, opts ...bool) (*wsResult, error) {
+	verbose := len(opts) > 0 && opts[0]
+	header := http.Header{}
+	header.Set("Authorization", "Token "+cfg.APIKey)
+
+	fmt.Printf("         URL: %s\n", wsURL)
+	conn, resp, err := websocket.DefaultDialer.Dial(wsURL, header)
+	if err != nil {
+		if resp != nil {
+			body, _ := io.ReadAll(resp.Body)
+			resp.Body.Close()
+			return nil, fmt.Errorf("websocket dial failed (HTTP %d): %s", resp.StatusCode, string(body))
+		}
+		return nil, fmt.Errorf("websocket dial failed: %w", err)
+	}
+	defer conn.Close()
+
+	// Send audio chunks in background
+	sendDone := make(chan struct{})
+	go func() {
+		defer close(sendDone)
+		sendAudioChunks(conn, cfg.Audio)
+	}()
+
+	// Read messages
+	conn.SetReadDeadline(time.Now().Add(30 * time.Second))
+
+	res := &wsResult{}
+	gotMetadata := false
+	gotResults := false
+
+	for {
+		_, msg, err := conn.ReadMessage()
+		if err != nil {
+			if websocket.IsCloseError(err, websocket.CloseNormalClosure) {
+				break
+			}
+			// If we already got results, a read error after close is expected
+			if gotResults {
+				break
+			}
+			return nil, fmt.Errorf("reading message: %w", err)
+		}
+
+		var m StreamingMessage
+		if err := json.Unmarshal(msg, &m); err != nil {
+			if verbose {
+				fmt.Printf("         [RAW] %s\n", string(msg))
+			}
+			continue
+		}
+
+		if verbose && m.Type != "Results" {
+			fmt.Printf("         [%s] %s\n", m.Type, string(msg))
+		}
+
+		switch m.Type {
+		case "Metadata":
+			gotMetadata = true
+		case "Results":
+			gotResults = true
+			res.Messages++
+			if len(m.Channel.Alternatives) > 0 {
+				t := m.Channel.Alternatives[0].Transcript
+				if t != "" {
+					if m.IsFinal {
+						res.Finals++
+						res.AllTranscripts = append(res.AllTranscripts, t)
+						if res.Transcript == "" {
+							res.Transcript = t
+						}
+						// Print final result in green
+						fmt.Printf("\033[32m%s \033[0m", t)
+					} else {
+						// Print interim in gray
+						fmt.Printf("\033[90m%s \033[0m", t)
+					}
+				}
+			}
+		default:
+			// Try to extract transcript from unknown message types (e.g. Flux v2)
+			var raw map[string]interface{}
+			if err := json.Unmarshal(msg, &raw); err == nil {
+				if ch, ok := raw["channel"].(map[string]interface{}); ok {
+					if alts, ok := ch["alternatives"].([]interface{}); ok && len(alts) > 0 {
+						if alt, ok := alts[0].(map[string]interface{}); ok {
+							if t, ok := alt["transcript"].(string); ok && t != "" {
+								gotResults = true
+								res.Messages++
+								res.Finals++
+								res.AllTranscripts = append(res.AllTranscripts, t)
+								if res.Transcript == "" {
+									res.Transcript = t
+								}
+								fmt.Printf("\r         \033[32m%s\033[0m\n", t)
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	<-sendDone
+
+	if !gotMetadata {
+		return nil, fmt.Errorf("no Metadata message received")
+	}
+	if !gotResults {
+		return nil, fmt.Errorf("no Results message received")
+	}
+	if res.Finals == 0 {
+		return nil, fmt.Errorf("no final results received")
+	}
+
+	return res, nil
+}
+
+func sendAudioChunks(conn *websocket.Conn, audio []byte) {
+	const chunkSize = 800
+	const interval = 50 * time.Millisecond
+
+	offset := 0
+	for offset < len(audio) {
+		end := offset + chunkSize
+		if end > len(audio) {
+			end = len(audio)
+		}
+		if err := conn.WriteMessage(websocket.BinaryMessage, audio[offset:end]); err != nil {
+			return
+		}
+		offset = end
+		time.Sleep(interval)
+	}
+
+	// Signal end of audio
+	conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"CloseStream"}`))
+}


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements IN-3792**
                                                                                                                                                                                                                                 
  - Sync Deepgram self-hosted Helm chart with upstream v0.32.0 (from v0.23.1), bumping all images to release-260319                                                                                                                           
  - Add Go-based validation tool (test/) for smoke-testing deployed Deepgram services (Nova streaming STT + Flux v2 STT)                                                                                                                        
  - Add Grafana monitoring dashboard from upstream                                                                                                                                                                                              
                                                                                                                                                                                                                                                
  Chart Upgrade (0.23.1-vf.2 → 0.32.0-vf.3)                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                                                                                                                                             
 Added Voiceflow Validation Test Tool (test/)                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                
  New Go CLI tool for smoke-testing deployments after upgrade:                                                                                                                                                                                  
  - Health check — verifies engine connectivity                                                                                                                                                                                                 
  - Streaming STT — WebSocket v1, real-time transcript streaming with interim/final results                                                                                                                                                     
  - Flux STT — WebSocket v2, turn-based transcript streaming                               
  - Batch STT — HTTP POST (for batch-capable models)                                                                                                                                                                                            
  - Supports separate URLs/models for Flux vs Nova (-flux-url, -flux-model)                                                                                                                                                                     
  - Reuses existing benchmarking/audio.8k.wav test audio 